### PR TITLE
Modulariza lógica en render, física y UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,6 @@
     </footer>
   </div>
 
-    <script src="main.js"></script>
+    <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,4 +1,7 @@
 'use strict';
+import { step } from './physics.js';
+import { render } from './render.js';
+import { setupUI, setTool, applyActionAt } from './ui.js';
 // ==============================================================
 //                    PARÁMETROS DEL MUNDO
 // ==============================================================
@@ -244,85 +247,6 @@ let fire = null;            // {x,y,r,t} incendio activo (centro, radio, tiempo 
 const FIRE_DURATION = 8;    // Segundos que dura un incendio disparado
 const METEOR_RADIUS = 6;    // Radio en tiles del impacto de meteorito
 
-function step(dt){
-  // Avanza el reloj global y el clima
-  simTime += dt;
-  worldTime += dt;
-  advanceWeather(dt);
-
-  // Disipación de incendios activos
-  if (fire){ fire.t -= dt; if (fire.t <= 0) fire = null; }
-
-  // Sub-steps de crecimiento vegetal para estabilidad (cada 0.5 s)
-  accPlant += dt;
-  while (accPlant >= 0.5){ accPlant -= 0.5; growPlants(); }
-
-  // Actualiza criaturas en orden inverso (para poder eliminar en caliente)
-  for (let i=animals.length-1; i>=0; i--){
-    const a = animals[i];
-    a.cooldown = Math.max(0, a.cooldown - dt);
-    a.age += dt;
-
-    // Muerte por longevidad
-    if (a.age > a.genes.lifespan){ animals.splice(i,1); continue; }
-
-    const base = (a.sp===SPECIES.HERB?HERB:CARN);
-    const night = isNight();
-    // Comportamiento diferencial nocturno (carnívoros mejoran, herbívoros empeoran)
-    const speedNightMul = (a.sp===SPECIES.CARN) ? (night?1.1:1.0) : (night?0.9:1.0);
-    const visionNightMul = (a.sp===SPECIES.CARN) ? (night?1.1:1.0) : (night?0.9:1.0);
-
-    const effSpeed = (a.speed * a.genes.speedMul) * speedNightMul;
-    const hungerRate = (a.sp===SPECIES.HERB?HERB.hungerRate:CARN.hungerRate) * a.genes.metabolismMul;
-
-    if (a.sp === SPECIES.HERB){
-      // Herbívoro: huye de depredadores, come plantas para recuperar energía
-      a.energy -= hungerRate * dt;
-      const threat = nearestPredator(a, (base.vision * a.genes.visionMul) * visionNightMul);
-      if (threat){
-        const ang = Math.atan2(a.y - threat.y, a.x - threat.x); // ángulo de huida
-        a.dir = ang + (Math.random()-0.5)*0.6;                   // añade ruido para evitar bloqueo
-      } else {
-        a.dir += (Math.random()-0.5) * a.wobble * dt * 2.0;      // deambular
-      }
-      moveCreature(a, dt, effSpeed);
-      clampInside(a);    // rebote en bordes/obstáculos
-      eatPlant(a);       // intenta comer si está sobre GRASS
-      // Reproducción asexuada simple con coste de energía y cooldown
-      if (a.energy > HERB.reproThreshold && a.cooldown<=0){
-        reproduce(a, SPECIES.HERB);
-        a.energy -= HERB.reproCost;
-        a.cooldown = 5;
-      }
-    } else {
-      // Carnívoro: persigue a la presa más cercana en rango de visión
-      a.energy -= hungerRate * dt;
-      const prey = nearestHerbivore(a, (base.vision * a.genes.visionMul) * visionNightMul);
-      if (prey){
-        const ang = Math.atan2(prey.y - a.y, prey.x - a.x); // ángulo hacia presa
-        a.dir = ang + (Math.random()-0.5)*0.2;              // leve ruido para variación
-      } else {
-        a.dir += (Math.random()-0.5) * a.wobble * dt * 1.3; // patrulla al azar
-      }
-      moveCreature(a, dt, effSpeed);
-      clampInside(a);
-      // Check de colisión simple por radio: si alcanza, come
-      if (prey && dist2(a, prey) < (a.r*TILE + prey.r*TILE) * (a.r*TILE + prey.r*TILE)){
-        a.energy += CARN.eatRate;
-        const idxPrey = animals.indexOf(prey);
-        if (idxPrey !== -1) animals.splice(idxPrey,1);
-      }
-      if (a.energy > CARN.reproThreshold && a.cooldown<=0){
-        reproduce(a, SPECIES.CARN);
-        a.energy -= CARN.reproCost;
-        a.cooldown = 7;
-      }
-    }
-
-    // Muerte por inanición
-    if (a.energy <= 0){ animals.splice(i,1); }
-  }
-}
 
 function growPlants(){
   // Regla local de crecimiento con factores: noche, clima, vecindad y agua cercana
@@ -457,120 +381,11 @@ function reproduce(parent, species){
 //                        INTERACCIÓN (FASE 4)
 // ==============================================================
 const TOOL = { INSPECT:'inspect', ADD_HERB:'add_herb', ADD_CARN:'add_carn', ERASER:'eraser', FOOD:'food', WATER:'water', BARRIER:'barrier' };
-let activeTool = TOOL.INSPECT; // Herramienta actual
 
-// Toolbar: click delega en data-tool y actualiza estado visual
+// Toolbar DOM
 const toolbar = document.getElementById('toolbar');
-toolbar.addEventListener('click', (e)=>{
-  const b = e.target.closest('button[data-tool]');
-  if (!b) return;
-  activeTool = b.dataset.tool;
-  for (const btn of toolbar.querySelectorAll('button[data-tool]')) btn.classList.toggle('active', btn===b);
-});
 
-// Botones de eventos especiales
-document.getElementById('evtFire').addEventListener('click', ()=> triggerFireCenter());
-document.getElementById('evtMeteor').addEventListener('click', ()=> strikeMeteor());
-document.getElementById('evtPlagueH').addEventListener('click', ()=> plague(SPECIES.HERB, 0.3));
-document.getElementById('evtPlagueC').addEventListener('click', ()=> plague(SPECIES.CARN, 0.3));
-
-// Atajos de teclado para herramientas y eventos
-window.addEventListener('keydown', (e)=>{
-  if (e.repeat) return; // evita autorepetición
-  const k = e.key.toLowerCase();
-  if (k==='1') setTool(TOOL.ADD_HERB);
-  else if (k==='2') setTool(TOOL.ADD_CARN);
-  else if (k==='3') setTool(TOOL.ERASER);
-  else if (k==='4') setTool(TOOL.FOOD);
-  else if (k==='5') setTool(TOOL.WATER);
-  else if (k==='6') setTool(TOOL.BARRIER);
-  else if (k==='7') setTool(TOOL.INSPECT);
-  else if (k==='f') triggerFireCenter();
-  else if (k==='m') strikeMeteor();
-  else if (k==='p') plague(SPECIES.HERB, 0.3);
-  else if (k==='o') plague(SPECIES.CARN, 0.3);
-});
-function setTool(t){
-  activeTool = t;
-  for (const btn of toolbar.querySelectorAll('button[data-tool]'))
-    btn.classList.toggle('active', btn.dataset.tool===t);
-}
-
-// Entrada de ratón (y arrastre) sobre el canvas
-let dragging = false;
-cvs.addEventListener('mousedown', (e)=>{ dragging = true; handleAt(e); });
-cvs.addEventListener('mousemove', (e)=>{ if (dragging) handleAt(e); });
-window.addEventListener('mouseup', ()=> dragging=false);
-cvs.addEventListener('click', (e)=>{ if (!dragging) handleAt(e); });
-
-function getTileFromEvent(e){
-  // Convierte coordenadas de pantalla a índice de tile respetando el tamaño CSS actual
-  const rect = cvs.getBoundingClientRect();
-  const x = Math.floor((e.clientX - rect.left) / (TILE * (rect.width / (WORLD_W*TILE))));
-  const y = Math.floor((e.clientY - rect.top) / (TILE * (rect.height / (WORLD_H*TILE))));
-  return {x: clamp(Math.floor(x),0,WORLD_W-1), y: clamp(Math.floor(y),0,WORLD_H-1)};
-}
-
-function handleAt(e){
-  const {x,y} = getTileFromEvent(e);
-  applyActionAt(x,y,activeTool);
-}
-
-function applyActionAt(x,y,action){
-  // Aplica la herramienta elegida sobre el tile (x,y)
-  const id = idx(x,y);
-  switch(action){
-    case TOOL.ADD_HERB:
-      animals.push({
-        sp: SPECIES.HERB, x:x+0.5, y:y+0.5, dir:Math.random()*Math.PI*2,
-        speed: HERB.baseSpeed, wobble: 0.4, r:0.32, energy:1.0, cooldown:0, age:0,
-        genes: defaultGenes(SPECIES.HERB)
-      });
-      break;
-    case TOOL.ADD_CARN:
-      animals.push({
-        sp: SPECIES.CARN, x:x+0.5, y:y+0.5, dir:Math.random()*Math.PI*2,
-        speed: CARN.baseSpeed, wobble: 0.4, r:0.36, energy:1.2, cooldown:0, age:0,
-        genes: defaultGenes(SPECIES.CARN)
-      });
-      break;
-    case TOOL.ERASER: {
-      // Elimina animales en un radio de 2 tiles alrededor del punto
-      const r=2; const r2=r*r;
-      for (let i=animals.length-1;i>=0;i--){
-        const a=animals[i];
-        const dx=a.x-(x+0.5), dy=a.y-(y+0.5);
-        if (dx*dx+dy*dy < r2) animals.splice(i,1);
-      }
-      break; }
-    case TOOL.FOOD:
-      if (terrain[id]===BIOME.GRASS){ plant[id] = clamp(plant[id] + 0.35, 0, 1); }
-      break;
-    case TOOL.WATER:
-      terrain[id] = BIOME.WATER; plant[id] = 0; // Convertir a agua limpia el tile
-      break;
-    case TOOL.BARRIER:
-      terrain[id] = BIOME.BARRIER; plant[id] = 0; // Obstáculo sólido
-      break;
-    case TOOL.INSPECT: {
-      const nearest = nearestAnimalTo(x+0.5,y+0.5, 3);
-      if (nearest){
-        // Muestra estado y genes en consola para depuración
-        console.log('Animal', {sp:nearest.sp===SPECIES.HERB?'HERB':'CARN', x:nearest.x, y:nearest.y, energy:nearest.energy, age:nearest.age, genes:nearest.genes});
-      }
-      break; }
-  }
-}
-
-function nearestAnimalTo(x,y, maxR){
-  // Escoge el animal más cercano a (x,y) dentro de un radio Euclídeo
-  let best=null, bestD=maxR*maxR;
-  for(const a of animals){
-    const dx=a.x-x, dy=a.y-y; const d=dx*dx+dy*dy;
-    if (d<bestD){ bestD=d; best=a; }
-  }
-  return best;
-}
+// Atajos y entrada gestionados en ui.js
 
 // ==============================================================
 //                   EVENTOS ESPECIALES (FASE 4)
@@ -611,89 +426,34 @@ function plague(species, ratio){
 //                            RENDER
 // ==============================================================
 let flashTimer = 0; // Cuenta atrás del flash de meteorito
-function render(){
-  // --- Capa de terreno base por tile ---
-  for(let y=0; y<WORLD_H; y++){
-    for(let x=0; x<WORLD_W; x++){
-      const id = idx(x,y);
-      const t = terrain[id];
-      if (t === BIOME.WATER){ ctx.fillStyle = COLORS.WATER; }
-      else if (t === BIOME.DIRT){ ctx.fillStyle = COLORS.DIRT; }
-      else if (t === BIOME.BARRIER){ ctx.fillStyle = COLORS.BARRIER; }
-      else { const p = plant[id]; ctx.fillStyle = p > 0.66 ? COLORS.GRASS2 : (p > 0.33 ? COLORS.GRASS1 : COLORS.GRASS0); }
-      ctx.fillRect(x*TILE, y*TILE, TILE, TILE);
-    }
-  }
 
-  // Sombreado sutil para orillas (tiles DIRT junto a WATER)
-  ctx.globalAlpha = 0.08; ctx.fillStyle = COLORS.SHORE;
-  for(let y=0; y<WORLD_H; y++){
-    for(let x=0; x<WORLD_W; x++){
-      if (terrain[idx(x,y)] !== BIOME.DIRT) continue;
-      let nearWater=false;
-      for(let dy=-1; dy<=1; dy++){
-        for(let dx=-1; dx<=1; dx++){
-          const nx=x+dx, ny=y+dy;
-          if (nx<0||ny<0||nx>=WORLD_W||ny>=WORLD_H) continue;
-          if (terrain[idx(nx,ny)]===BIOME.WATER){ nearWater=true; break; }
-        }
-        if(nearWater) break;
-      }
-      if (nearWater) ctx.fillRect(x*TILE, y*TILE, TILE, TILE);
-    }
-  }
-  ctx.globalAlpha = 1;
-
-  // Detalle de brotes (ruido visual basado en densidad de planta)
-  ctx.globalAlpha = 0.35; ctx.fillStyle = COLORS.GRASS2;
-  for(let y=0; y<WORLD_H; y++){
-    for(let x=0; x<WORLD_W; x++){
-      if (terrain[idx(x,y)] !== BIOME.GRASS) continue;
-      const p = plant[idx(x,y)]; if (p < 0.2) continue;
-      const n = (p*3)|0; // más densidad => más trazos
-      for(let i=0;i<n;i++){
-        const ox = (Math.random()*0.8+0.1)*TILE; const oy = (Math.random()*0.8+0.1)*TILE;
-        ctx.fillRect(x*TILE+ox, y*TILE+oy, 1, 2);
-      }
-    }
-  }
-  ctx.globalAlpha = 1;
-
-  // Dibujo de animales (círculo + triángulo direccional)
-  for(const a of animals){
-    ctx.fillStyle = (a.sp===SPECIES.HERB) ? '#fef08a' : '#ef4444';
-    const r = a.r * TILE;
-    ctx.beginPath(); ctx.arc(a.x*TILE, a.y*TILE, r, 0, Math.PI*2); ctx.fill();
-    ctx.beginPath(); const ear = r*0.7; // triángulo direccional
-    ctx.moveTo(a.x*TILE + Math.cos(a.dir)*r, a.y*TILE + Math.sin(a.dir)*r);
-    ctx.lineTo(a.x*TILE + Math.cos(a.dir+0.8)*ear, a.y*TILE + Math.sin(a.dir+0.8)*ear);
-    ctx.lineTo(a.x*TILE + Math.cos(a.dir-0.8)*ear, a.y*TILE + Math.sin(a.dir-0.8)*ear);
-    ctx.closePath(); ctx.fill();
-  }
-
-  // Tinte nocturno proporcional al factor de luz
-  const nightAlpha = 1 - daylightFactor();
-  if (nightAlpha > 0.02){ ctx.fillStyle = `rgba(6, 8, 14, ${0.55*nightAlpha})`; ctx.fillRect(0,0,WORLD_W*TILE, WORLD_H*TILE); }
-
-  // Efectos de clima (líneas de lluvia / filtro de sequía)
-  if (weatherState===WEATHER.RAIN){
-    ctx.globalAlpha = 0.4; ctx.strokeStyle = '#93c5fd';
-    for(let i=0;i<120;i++){ const x = Math.random()*WORLD_W*TILE; const y = Math.random()*WORLD_H*TILE; ctx.beginPath(); ctx.moveTo(x,y); ctx.lineTo(x+2,y+8); ctx.stroke(); }
-    ctx.globalAlpha = 1;
-  } else if (weatherState===WEATHER.DROUGHT){
-    ctx.globalAlpha = 0.15; ctx.fillStyle = '#f59e0b'; ctx.fillRect(0,0,WORLD_W*TILE, WORLD_H*TILE); ctx.globalAlpha = 1;
-  }
-
-  // Overlay del incendio
-  if (fire){
-    ctx.globalAlpha = 0.18; ctx.fillStyle = '#fb923c';
-    ctx.beginPath(); ctx.arc(fire.x*TILE, fire.y*TILE, fire.r*TILE, 0, Math.PI*2); ctx.fill();
-    ctx.globalAlpha = 1;
-  }
-
-  // Flash de meteorito (pantalla blanca breve)
-  if (flashTimer>0){ flashTimer -= 1/60; ctx.globalAlpha = Math.max(0, flashTimer/0.3); ctx.fillStyle = '#ffffff'; ctx.fillRect(0,0,WORLD_W*TILE, WORLD_H*TILE); ctx.globalAlpha = 1; }
-}
+// Objeto de estado compartido entre módulos
+const state = {
+  get simTime(){ return simTime; },
+  set simTime(v){ simTime = v; },
+  get worldTime(){ return worldTime; },
+  set worldTime(v){ worldTime = v; },
+  get weatherTimer(){ return weatherTimer; },
+  set weatherTimer(v){ weatherTimer = v; },
+  get weatherState(){ return weatherState; },
+  set weatherState(v){ weatherState = v; },
+  get accPlant(){ return accPlant; },
+  set accPlant(v){ accPlant = v; },
+  get flashTimer(){ return flashTimer; },
+  set flashTimer(v){ flashTimer = v; },
+  get fire(){ return fire; },
+  set fire(v){ fire = v; },
+  TILE, WORLD_W, WORLD_H,
+  animals, plant, terrain,
+  SPECIES, HERB, CARN, HERB_START, CARN_START,
+  idx, clamp, WEATHER, WEATHER_NAMES, BIOME, COLORS,
+  TOOL, defaultGenes, advanceWeather, growPlants, isNight,
+  nearestPredator, nearestHerbivore, moveCreature, clampInside,
+  eatPlant, reproduce, dist2, daylightFactor,
+  triggerFireCenter, strikeMeteor, plague,
+  toolbar, cvs, ctx,
+  activeTool: TOOL.INSPECT
+};
 
 // ==============================================================
 //                        BUCLE PRINCIPAL
@@ -709,8 +469,8 @@ function loop(now){
   const dt = Math.min(0.05, (now - last)/1000); // Delta tiempo con tope (50ms) para estabilidad
   last = now;
 
-  step(dt);    // Actualización de estado
-  render();    // Dibujo de frame
+  step(state, dt);    // Actualización de estado
+  render(state);      // Dibujo de frame
 
   // UI cada ~0.5s
   frames++; fpsTime += dt;
@@ -741,10 +501,11 @@ function countGreens(){
 // ==============================================================
 //                           INIT
 // ==============================================================
+setupUI(state);
 generateTerrain();                 // Crea el mapa base
 spawnAnimals();                    // Población inicial
-weatherTimer = 0; advanceWeather(0.01); // Forzar selección de clima inicial
-setTool(TOOL.INSPECT);            // Herramienta por defecto
+state.weatherTimer = 0; advanceWeather(0.01); // Forzar selección de clima inicial
+setTool(state, TOOL.INSPECT);            // Herramienta por defecto
 requestAnimationFrame((t)=>{ last=t; loop(t); }); // Arranque del bucle
 
 // ==============================================================
@@ -779,7 +540,7 @@ function runSelfTests(){
   };
   const {x:gx,y:gy} = findGrassTile();
   const idG = idx(gx,gy); const oldPlant=plant[idG];
-  applyActionAt(gx,gy,TOOL.FOOD); add('Comida aumenta planta', plant[idG] >= oldPlant);
+  applyActionAt(state,gx,gy,TOOL.FOOD); add('Comida aumenta planta', plant[idG] >= oldPlant);
 
   // Verifica FIX de RNG: defaultGenes sin rng debe funcionar y estar en rango
   let okGenes = true; let g;
@@ -794,12 +555,12 @@ function runSelfTests(){
 
   // Añadir animal mediante herramienta debe incrementar población
   const before = animals.length;
-  applyActionAt(gx,gy,TOOL.ADD_HERB);
+  applyActionAt(state,gx,gy,TOOL.ADD_HERB);
   add('ADD_HERB incrementa población', animals.length === before+1, `before=${before} now=${animals.length}`);
 
   // Cambios de terreno por herramientas
-  applyActionAt(gx,gy,TOOL.WATER);   add('Agua cambia a WATER', terrain[idG] === BIOME.WATER);
-  applyActionAt(gx,gy,TOOL.BARRIER); add('Barrera cambia a BARRIER', terrain[idG] === BIOME.BARRIER);
+  applyActionAt(state,gx,gy,TOOL.WATER);   add('Agua cambia a WATER', terrain[idG] === BIOME.WATER);
+  applyActionAt(state,gx,gy,TOOL.BARRIER); add('Barrera cambia a BARRIER', terrain[idG] === BIOME.BARRIER);
 
   // Reporte visual breve
   const passed = tests.filter(t=>t.pass).length;

--- a/physics.js
+++ b/physics.js
@@ -1,0 +1,74 @@
+export function step(state, dt){
+  state.simTime += dt;
+  state.worldTime += dt;
+  state.advanceWeather(dt);
+
+  if (state.fire){
+    state.fire.t -= dt;
+    if (state.fire.t <= 0) state.fire = null;
+  }
+
+  state.accPlant += dt;
+  while (state.accPlant >= 0.5){
+    state.accPlant -= 0.5;
+    state.growPlants();
+  }
+
+  for (let i=state.animals.length-1; i>=0; i--){
+    const a = state.animals[i];
+    a.cooldown = Math.max(0, a.cooldown - dt);
+    a.age += dt;
+
+    if (a.age > a.genes.lifespan){ state.animals.splice(i,1); continue; }
+
+    const base = (a.sp===state.SPECIES.HERB?state.HERB:state.CARN);
+    const night = state.isNight();
+    const speedNightMul = (a.sp===state.SPECIES.CARN) ? (night?1.1:1.0) : (night?0.9:1.0);
+    const visionNightMul = (a.sp===state.SPECIES.CARN) ? (night?1.1:1.0) : (night?0.9:1.0);
+
+    const effSpeed = (a.speed * a.genes.speedMul) * speedNightMul;
+    const hungerRate = (a.sp===state.SPECIES.HERB?state.HERB.hungerRate:state.CARN.hungerRate) * a.genes.metabolismMul;
+
+    if (a.sp === state.SPECIES.HERB){
+      a.energy -= hungerRate * dt;
+      const threat = state.nearestPredator(a, (base.vision * a.genes.visionMul) * visionNightMul);
+      if (threat){
+        const ang = Math.atan2(a.y - threat.y, a.x - threat.x);
+        a.dir = ang + (Math.random()-0.5)*0.6;
+      } else {
+        a.dir += (Math.random()-0.5) * a.wobble * dt * 2.0;
+      }
+      state.moveCreature(a, dt, effSpeed);
+      state.clampInside(a);
+      state.eatPlant(a);
+      if (a.energy > state.HERB.reproThreshold && a.cooldown<=0){
+        state.reproduce(a, state.SPECIES.HERB);
+        a.energy -= state.HERB.reproCost;
+        a.cooldown = 5;
+      }
+    } else {
+      a.energy -= hungerRate * dt;
+      const prey = state.nearestHerbivore(a, (base.vision * a.genes.visionMul) * visionNightMul);
+      if (prey){
+        const ang = Math.atan2(prey.y - a.y, prey.x - a.x);
+        a.dir = ang + (Math.random()-0.5)*0.2;
+      } else {
+        a.dir += (Math.random()-0.5) * a.wobble * dt * 1.3;
+      }
+      state.moveCreature(a, dt, effSpeed);
+      state.clampInside(a);
+      if (prey && state.dist2(a, prey) < (a.r*state.TILE + prey.r*state.TILE) * (a.r*state.TILE + prey.r*state.TILE)){
+        a.energy += state.CARN.eatRate;
+        const idxPrey = state.animals.indexOf(prey);
+        if (idxPrey !== -1) state.animals.splice(idxPrey,1);
+      }
+      if (a.energy > state.CARN.reproThreshold && a.cooldown<=0){
+        state.reproduce(a, state.SPECIES.CARN);
+        a.energy -= state.CARN.reproCost;
+        a.cooldown = 7;
+      }
+    }
+
+    if (a.energy <= 0){ state.animals.splice(i,1); }
+  }
+}

--- a/render.js
+++ b/render.js
@@ -1,0 +1,79 @@
+export function render(state){
+  const { ctx, WORLD_W, WORLD_H, TILE, terrain, plant, COLORS, BIOME, animals, SPECIES, weatherState, WEATHER, fire } = state;
+  let { flashTimer } = state;
+
+  for(let y=0; y<WORLD_H; y++){
+    for(let x=0; x<WORLD_W; x++){
+      const id = state.idx(x,y);
+      const t = terrain[id];
+      if (t === BIOME.WATER){ ctx.fillStyle = COLORS.WATER; }
+      else if (t === BIOME.DIRT){ ctx.fillStyle = COLORS.DIRT; }
+      else if (t === BIOME.BARRIER){ ctx.fillStyle = COLORS.BARRIER; }
+      else { const p = plant[id]; ctx.fillStyle = p > 0.66 ? COLORS.GRASS2 : (p > 0.33 ? COLORS.GRASS1 : COLORS.GRASS0); }
+      ctx.fillRect(x*TILE, y*TILE, TILE, TILE);
+    }
+  }
+
+  ctx.globalAlpha = 0.08; ctx.fillStyle = COLORS.SHORE;
+  for(let y=0; y<WORLD_H; y++){
+    for(let x=0; x<WORLD_W; x++){
+      if (terrain[state.idx(x,y)] !== BIOME.DIRT) continue;
+      let nearWater=false;
+      for(let dy=-1; dy<=1; dy++){
+        for(let dx=-1; dx<=1; dx++){
+          const nx=x+dx, ny=y+dy;
+          if (nx<0||ny<0||nx>=WORLD_W||ny>=WORLD_H) continue;
+          if (terrain[state.idx(nx,ny)]===BIOME.WATER){ nearWater=true; break; }
+        }
+        if(nearWater) break;
+      }
+      if (nearWater) ctx.fillRect(x*TILE, y*TILE, TILE, TILE);
+    }
+  }
+  ctx.globalAlpha = 1;
+
+  ctx.globalAlpha = 0.35; ctx.fillStyle = COLORS.GRASS2;
+  for(let y=0; y<WORLD_H; y++){
+    for(let x=0; x<WORLD_W; x++){
+      if (terrain[state.idx(x,y)] !== BIOME.GRASS) continue;
+      const p = plant[state.idx(x,y)]; if (p < 0.2) continue;
+      const n = (p*3)|0;
+      for(let i=0;i<n;i++){
+        const ox = (Math.random()*0.8+0.1)*TILE; const oy = (Math.random()*0.8+0.1)*TILE;
+        ctx.fillRect(x*TILE+ox, y*TILE+oy, 1, 2);
+      }
+    }
+  }
+  ctx.globalAlpha = 1;
+
+  for(const a of animals){
+    ctx.fillStyle = (a.sp===SPECIES.HERB) ? '#fef08a' : '#ef4444';
+    const r = a.r * TILE;
+    ctx.beginPath(); ctx.arc(a.x*TILE, a.y*TILE, r, 0, Math.PI*2); ctx.fill();
+    ctx.beginPath(); const ear = r*0.7;
+    ctx.moveTo(a.x*TILE + Math.cos(a.dir)*r, a.y*TILE + Math.sin(a.dir)*r);
+    ctx.lineTo(a.x*TILE + Math.cos(a.dir+0.8)*ear, a.y*TILE + Math.sin(a.dir+0.8)*ear);
+    ctx.lineTo(a.x*TILE + Math.cos(a.dir-0.8)*ear, a.y*TILE + Math.sin(a.dir-0.8)*ear);
+    ctx.closePath(); ctx.fill();
+  }
+
+  const nightAlpha = 1 - state.daylightFactor();
+  if (nightAlpha > 0.02){ ctx.fillStyle = `rgba(6, 8, 14, ${0.55*nightAlpha})`; ctx.fillRect(0,0,WORLD_W*TILE, WORLD_H*TILE); }
+
+  if (weatherState===WEATHER.RAIN){
+    ctx.globalAlpha = 0.4; ctx.strokeStyle = '#93c5fd';
+    for(let i=0;i<120;i++){ const x = Math.random()*WORLD_W*TILE; const y = Math.random()*WORLD_H*TILE; ctx.beginPath(); ctx.moveTo(x,y); ctx.lineTo(x+2,y+8); ctx.stroke(); }
+    ctx.globalAlpha = 1;
+  } else if (weatherState===WEATHER.DROUGHT){
+    ctx.globalAlpha = 0.15; ctx.fillStyle = '#f59e0b'; ctx.fillRect(0,0,WORLD_W*TILE, WORLD_H*TILE); ctx.globalAlpha = 1;
+  }
+
+  if (fire){
+    ctx.globalAlpha = 0.18; ctx.fillStyle = '#fb923c';
+    ctx.beginPath(); ctx.arc(fire.x*TILE, fire.y*TILE, fire.r*TILE, 0, Math.PI*2); ctx.fill();
+    ctx.globalAlpha = 1;
+  }
+
+  if (flashTimer>0){ flashTimer -= 1/60; ctx.globalAlpha = Math.max(0, flashTimer/0.3); ctx.fillStyle = '#ffffff'; ctx.fillRect(0,0,WORLD_W*TILE, WORLD_H*TILE); ctx.globalAlpha = 1; }
+  state.flashTimer = flashTimer;
+}

--- a/ui.js
+++ b/ui.js
@@ -1,0 +1,95 @@
+export function setTool(state, t){
+  state.activeTool = t;
+  for (const btn of state.toolbar.querySelectorAll('button[data-tool]'))
+    btn.classList.toggle('active', btn.dataset.tool===t);
+}
+
+function getTileFromEvent(state, e){
+  const rect = state.cvs.getBoundingClientRect();
+  const x = Math.floor((e.clientX - rect.left) / (state.TILE * (rect.width / (state.WORLD_W*state.TILE))));
+  const y = Math.floor((e.clientY - rect.top) / (state.TILE * (rect.height / (state.WORLD_H*state.TILE))));
+  return {x: state.clamp(Math.floor(x),0,state.WORLD_W-1), y: state.clamp(Math.floor(y),0,state.WORLD_H-1)};
+}
+
+function handleAt(state, e){
+  const {x,y} = getTileFromEvent(state,e);
+  applyActionAt(state,x,y,state.activeTool);
+}
+
+export function applyActionAt(state,x,y,action){
+  const id = state.idx(x,y);
+  switch(action){
+    case state.TOOL.ADD_HERB:
+      state.animals.push({
+        sp: state.SPECIES.HERB, x:x+0.5, y:y+0.5, dir:Math.random()*Math.PI*2,
+        speed: state.HERB.baseSpeed, wobble: 0.4, r:0.32, energy:1.0, cooldown:0, age:0,
+        genes: state.defaultGenes(state.SPECIES.HERB)
+      });
+      break;
+    case state.TOOL.ADD_CARN:
+      state.animals.push({
+        sp: state.SPECIES.CARN, x:x+0.5, y:y+0.5, dir:Math.random()*Math.PI*2,
+        speed: state.CARN.baseSpeed, wobble: 0.4, r:0.36, energy:1.2, cooldown:0, age:0,
+        genes: state.defaultGenes(state.SPECIES.CARN)
+      });
+      break;
+    case state.TOOL.ERASER: {
+      const r=2; const r2=r*r;
+      for (let i=state.animals.length-1;i>=0;i--){
+        const a=state.animals[i];
+        const dx=a.x-(x+0.5), dy=a.y-(y+0.5);
+        if (dx*dx+dy*dy < r2) state.animals.splice(i,1);
+      }
+      break; }
+    case state.TOOL.FOOD:
+      if (state.terrain[id]===state.BIOME.GRASS){ state.plant[id] = state.clamp(state.plant[id] + 0.35, 0, 1); }
+      break;
+    case state.TOOL.WATER:
+      state.terrain[id] = state.BIOME.WATER; state.plant[id] = 0;
+      break;
+    case state.TOOL.BARRIER:
+      state.terrain[id] = state.BIOME.BARRIER; state.plant[id] = 0;
+      break;
+    case state.TOOL.INSPECT: {
+      const nearest = nearestAnimalTo(state,x+0.5,y+0.5,3);
+      if (nearest){
+        console.log('Animal', {sp:nearest.sp===state.SPECIES.HERB?'HERB':'CARN', x:nearest.x, y:nearest.y, energy:nearest.energy, age:nearest.age, genes:nearest.genes});
+      }
+      break; }
+  }
+}
+
+function nearestAnimalTo(state,x,y,maxR){
+  let best=null, bestD=maxR*maxR;
+  for(const a of state.animals){
+    const dx=a.x-x, dy=a.y-y; const d=dx*dx+dy*dy;
+    if (d<bestD){ bestD=d; best=a; }
+  }
+  return best;
+}
+
+export function setupUI(state){
+  state.toolbar.querySelectorAll('button[data-tool]').forEach(btn=>{
+    btn.addEventListener('click', ()=> setTool(state, btn.dataset.tool));
+  });
+
+  let dragging=false;
+  state.cvs.addEventListener('mousedown', e=>{ dragging=true; handleAt(state,e); });
+  state.cvs.addEventListener('mousemove', e=>{ if(dragging) handleAt(state,e); });
+  window.addEventListener('mouseup', ()=> dragging=false);
+  state.cvs.addEventListener('click', e=>{ if(!dragging) handleAt(state,e); });
+
+  window.addEventListener('keydown', (e)=>{
+    const map = { '1':'inspect','2':'add_herb','3':'eraser','4':'food','5':'water','6':'barrier' };
+    if(map[e.key]) setTool(state, map[e.key]);
+    else if(e.key==='f' || e.key==='F') state.triggerFireCenter();
+    else if(e.key==='m' || e.key==='M') state.strikeMeteor();
+    else if(e.key==='p' || e.key==='P') state.plague(state.SPECIES.HERB,0.35);
+    else if(e.key==='o' || e.key==='O') state.plague(state.SPECIES.CARN,0.5);
+  });
+
+  document.getElementById('evtFire').addEventListener('click', state.triggerFireCenter);
+  document.getElementById('evtMeteor').addEventListener('click', state.strikeMeteor);
+  document.getElementById('evtPlagueH').addEventListener('click', ()=> state.plague(state.SPECIES.HERB,0.35));
+  document.getElementById('evtPlagueC').addEventListener('click', ()=> state.plague(state.SPECIES.CARN,0.5));
+}


### PR DESCRIPTION
## Summary
- Se separó la lógica de física, renderizado y UI en módulos `physics.js`, `render.js` y `ui.js`
- `main.js` ahora orquesta los módulos mediante un objeto de estado compartido
- `index.html` carga `main.js` como módulo ES

## Testing
- `node --check main.js render.js physics.js ui.js`


------
https://chatgpt.com/codex/tasks/task_e_689c12fbadd083319f3aa4307cdd10c5