### PR TITLE
Add sprite-based rendering and engine optimizations

### DIFF
--- a/physics.js
+++ b/physics.js
@@ -14,6 +14,16 @@ export function step(state, dt){
     state.growPlants();
   }
 
+  // Rebuild spatial grid for faster neighborhood queries
+  const grid = state.grid;
+  for (let i=0;i<grid.length;i++) grid[i].length = 0;
+  for (const a of state.animals){
+    const gx = Math.floor(a.x / state.GRID_SIZE);
+    const gy = Math.floor(a.y / state.GRID_SIZE);
+    const gi = state.cellIndex(gx,gy);
+    grid[gi].push(a);
+  }
+
   for (let i=state.animals.length-1; i>=0; i--){
     const a = state.animals[i];
     a.cooldown = Math.max(0, a.cooldown - dt);

--- a/render.js
+++ b/render.js
@@ -1,67 +1,60 @@
 export function render(state){
-  const { ctx, WORLD_W, WORLD_H, TILE, terrain, plant, COLORS, BIOME, animals, SPECIES, weatherState, WEATHER, fire } = state;
+  const { ctx, WORLD_W, WORLD_H, TILE, terrain, plant, BIOME, animals, SPECIES, weatherState, WEATHER, fire, sprites } = state;
   let { flashTimer } = state;
 
-  for(let y=0; y<WORLD_H; y++){
-    for(let x=0; x<WORLD_W; x++){
-      const id = state.idx(x,y);
-      const t = terrain[id];
-      if (t === BIOME.WATER){ ctx.fillStyle = COLORS.WATER; }
-      else if (t === BIOME.DIRT){ ctx.fillStyle = COLORS.DIRT; }
-      else if (t === BIOME.BARRIER){ ctx.fillStyle = COLORS.BARRIER; }
-      else { const p = plant[id]; ctx.fillStyle = p > 0.66 ? COLORS.GRASS2 : (p > 0.33 ? COLORS.GRASS1 : COLORS.GRASS0); }
-      ctx.fillRect(x*TILE, y*TILE, TILE, TILE);
-    }
-  }
-
-  ctx.globalAlpha = 0.08; ctx.fillStyle = COLORS.SHORE;
-  for(let y=0; y<WORLD_H; y++){
-    for(let x=0; x<WORLD_W; x++){
-      if (terrain[state.idx(x,y)] !== BIOME.DIRT) continue;
-      let nearWater=false;
-      for(let dy=-1; dy<=1; dy++){
-        for(let dx=-1; dx<=1; dx++){
-          const nx=x+dx, ny=y+dy;
-          if (nx<0||ny<0||nx>=WORLD_W||ny>=WORLD_H) continue;
-          if (terrain[state.idx(nx,ny)]===BIOME.WATER){ nearWater=true; break; }
-        }
-        if(nearWater) break;
+  // Pre-rendered terrain layer for performance
+  if (state.redrawTerrain || !state.terrainCanvas){
+    const tcv = state.terrainCanvas || (state.terrainCanvas = document.createElement('canvas'));
+    tcv.width = WORLD_W*TILE;
+    tcv.height = WORLD_H*TILE;
+    const tctx = tcv.getContext('2d');
+    for(let y=0; y<WORLD_H; y++){
+      for(let x=0; x<WORLD_W; x++){
+        const id = state.idx(x,y);
+        const t = terrain[id];
+        let img = sprites.terrain.grass;
+        if (t === BIOME.WATER) img = sprites.terrain.water;
+        else if (t === BIOME.DIRT) img = sprites.terrain.dirt;
+        else if (t === BIOME.BARRIER) img = sprites.terrain.barrier;
+        tctx.drawImage(img, x*TILE, y*TILE, TILE, TILE);
       }
-      if (nearWater) ctx.fillRect(x*TILE, y*TILE, TILE, TILE);
     }
+    state.redrawTerrain = false;
   }
-  ctx.globalAlpha = 1;
+  ctx.drawImage(state.terrainCanvas,0,0);
 
-  ctx.globalAlpha = 0.35; ctx.fillStyle = COLORS.GRASS2;
+  // Plant sprites with growth-based scaling
   for(let y=0; y<WORLD_H; y++){
     for(let x=0; x<WORLD_W; x++){
       if (terrain[state.idx(x,y)] !== BIOME.GRASS) continue;
-      const p = plant[state.idx(x,y)]; if (p < 0.2) continue;
-      const n = (p*3)|0;
-      for(let i=0;i<n;i++){
-        const ox = (Math.random()*0.8+0.1)*TILE; const oy = (Math.random()*0.8+0.1)*TILE;
-        ctx.fillRect(x*TILE+ox, y*TILE+oy, 1, 2);
-      }
+      const p = plant[state.idx(x,y)];
+      if (p < 0.05) continue;
+      const size = TILE * (0.3 + p*0.7);
+      const px = x*TILE + (TILE-size)/2;
+      const py = y*TILE + (TILE-size)/2;
+      ctx.drawImage(sprites.plant, px, py, size, size);
     }
   }
-  ctx.globalAlpha = 1;
 
+  // Animated animal sprites
+  const frame = Math.floor(state.simTime*6)%2;
   for(const a of animals){
-    ctx.fillStyle = (a.sp===SPECIES.HERB) ? '#fef08a' : '#ef4444';
-    const r = a.r * TILE;
-    ctx.beginPath(); ctx.arc(a.x*TILE, a.y*TILE, r, 0, Math.PI*2); ctx.fill();
-    ctx.beginPath(); const ear = r*0.7;
-    ctx.moveTo(a.x*TILE + Math.cos(a.dir)*r, a.y*TILE + Math.sin(a.dir)*r);
-    ctx.lineTo(a.x*TILE + Math.cos(a.dir+0.8)*ear, a.y*TILE + Math.sin(a.dir+0.8)*ear);
-    ctx.lineTo(a.x*TILE + Math.cos(a.dir-0.8)*ear, a.y*TILE + Math.sin(a.dir-0.8)*ear);
-    ctx.closePath(); ctx.fill();
+    const imgSet = (a.sp===SPECIES.HERB)? sprites.herb : sprites.carn;
+    const img = imgSet[frame];
+    const size = a.r*2*TILE;
+    ctx.save();
+    ctx.translate(a.x*TILE, a.y*TILE);
+    ctx.rotate(a.dir);
+    ctx.drawImage(img, -size/2, -size/2, size, size);
+    ctx.restore();
   }
 
-  const nightAlpha = 1 - state.daylightFactor();
-  if (nightAlpha > 0.02){ ctx.fillStyle = `rgba(6, 8, 14, ${0.55*nightAlpha})`; ctx.fillRect(0,0,WORLD_W*TILE, WORLD_H*TILE); }
+  // Time-of-day and weather color overlays
+  const night = 1 - state.daylightFactor();
+  if (night > 0.02){ ctx.globalAlpha = 0.55*night; ctx.fillStyle = '#06080e'; ctx.fillRect(0,0,WORLD_W*TILE, WORLD_H*TILE); ctx.globalAlpha=1; }
 
   if (weatherState===WEATHER.RAIN){
-    ctx.globalAlpha = 0.4; ctx.strokeStyle = '#93c5fd';
+    ctx.globalAlpha = 0.15; ctx.fillStyle = '#0ea5e9'; ctx.fillRect(0,0,WORLD_W*TILE, WORLD_H*TILE); ctx.globalAlpha = 0.4; ctx.strokeStyle = '#93c5fd';
     for(let i=0;i<120;i++){ const x = Math.random()*WORLD_W*TILE; const y = Math.random()*WORLD_H*TILE; ctx.beginPath(); ctx.moveTo(x,y); ctx.lineTo(x+2,y+8); ctx.stroke(); }
     ctx.globalAlpha = 1;
   } else if (weatherState===WEATHER.DROUGHT){

--- a/sprites.js
+++ b/sprites.js
@@ -1,0 +1,109 @@
+/**
+ * Simple sprite generator for Ecosim.
+ * Generates small canvas-based sprites for animals, plants
+ * and terrain textures so the simulation does not depend on
+ * external image assets.
+ */
+
+function makeCanvas(w, h, draw) {
+  const c = document.createElement('canvas');
+  c.width = w;
+  c.height = h;
+  const ctx = c.getContext('2d');
+  draw(ctx, w, h);
+  return c;
+}
+
+// Terrain textures -----------------------------------------------------------
+function texWater(){
+  return makeCanvas(16,16,(ctx)=>{
+    ctx.fillStyle = '#1e40af';
+    ctx.fillRect(0,0,16,16);
+    ctx.fillStyle = '#2563eb';
+    for(let i=0;i<16;i+=4){
+      ctx.fillRect(0,i,16,2);
+    }
+  });
+}
+function texGrass(){
+  return makeCanvas(16,16,(ctx)=>{
+    ctx.fillStyle = '#14532d';
+    ctx.fillRect(0,0,16,16);
+    ctx.fillStyle = '#22c55e';
+    for(let i=0;i<20;i++){
+      ctx.fillRect(Math.random()*16, Math.random()*16,1,1);
+    }
+  });
+}
+function texDirt(){
+  return makeCanvas(16,16,(ctx)=>{
+    ctx.fillStyle = '#6b4226';
+    ctx.fillRect(0,0,16,16);
+    ctx.fillStyle = '#8b5e3c';
+    for(let i=0;i<16;i++){
+      ctx.fillRect(Math.random()*16, Math.random()*16,1,1);
+    }
+  });
+}
+function texBarrier(){
+  return makeCanvas(16,16,(ctx)=>{
+    ctx.fillStyle = '#64748b';
+    ctx.fillRect(0,0,16,16);
+    ctx.strokeStyle = '#94a3b8';
+    ctx.strokeRect(0.5,0.5,15,15);
+  });
+}
+
+// Plant sprite ---------------------------------------------------------------
+function makePlant(){
+  return makeCanvas(12,12,(ctx)=>{
+    ctx.fillStyle = '#166534';
+    ctx.fillRect(5,7,2,5);
+    ctx.fillStyle = '#22c55e';
+    ctx.beginPath();
+    ctx.moveTo(6,7);
+    ctx.lineTo(2,3);
+    ctx.lineTo(3,3);
+    ctx.lineTo(6,6);
+    ctx.lineTo(9,3);
+    ctx.lineTo(10,3);
+    ctx.closePath();
+    ctx.fill();
+  });
+}
+
+// Animal sprites -------------------------------------------------------------
+function herbFrame(offset){
+  return makeCanvas(16,16,(ctx)=>{
+    ctx.fillStyle = '#fef08a';
+    ctx.beginPath();
+    ctx.arc(8,8,5,0,Math.PI*2);
+    ctx.fill();
+    ctx.fillStyle = '#92400e';
+    ctx.fillRect(4+offset,12,3,3);
+    ctx.fillRect(9-offset,12,3,3);
+  });
+}
+function carnFrame(offset){
+  return makeCanvas(16,16,(ctx)=>{
+    ctx.fillStyle = '#ef4444';
+    ctx.beginPath();
+    ctx.arc(8,8,5,0,Math.PI*2);
+    ctx.fill();
+    ctx.fillStyle = '#7f1d1d';
+    ctx.fillRect(4+offset,12,3,3);
+    ctx.fillRect(9-offset,12,3,3);
+  });
+}
+
+export const sprites = {
+  terrain: {
+    water: texWater(),
+    grass: texGrass(),
+    dirt: texDirt(),
+    barrier: texBarrier()
+  },
+  plant: makePlant(),
+  herb: [herbFrame(0), herbFrame(2)],
+  carn: [carnFrame(0), carnFrame(2)]
+};

--- a/ui.js
+++ b/ui.js
@@ -45,10 +45,10 @@ export function applyActionAt(state,x,y,action){
       if (state.terrain[id]===state.BIOME.GRASS){ state.plant[id] = state.clamp(state.plant[id] + 0.35, 0, 1); }
       break;
     case state.TOOL.WATER:
-      state.terrain[id] = state.BIOME.WATER; state.plant[id] = 0;
+      state.terrain[id] = state.BIOME.WATER; state.plant[id] = 0; state.redrawTerrain = true;
       break;
     case state.TOOL.BARRIER:
-      state.terrain[id] = state.BIOME.BARRIER; state.plant[id] = 0;
+      state.terrain[id] = state.BIOME.BARRIER; state.plant[id] = 0; state.redrawTerrain = true;
       break;
     case state.TOOL.INSPECT: {
       const nearest = nearestAnimalTo(state,x+0.5,y+0.5,3);


### PR DESCRIPTION
## Summary
- add canvas-generated sprites and textures for animals, plants and terrain
- render animated sprites and tint terrain by time of day and weather
- optimize entity search with spatial grid and cache terrain drawing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c1c2d39f48331a8a4ca6397b4373a